### PR TITLE
Fixes #10

### DIFF
--- a/Measure-Benchmark.ps1
+++ b/Measure-Benchmark.ps1
@@ -87,14 +87,14 @@
 
     begin {
         $cpuSpeed = 
-            if (Get-Variable -ErrorAction Ignore -ValueOnly IsLinux) {
+            if ($executionContext.SessionState.PSVariable.Get('IsLinux').Value) {
                 Get-Content /proc/cpuinfo -Raw -ErrorAction SilentlyContinue | 
                     Select-String "(?<Unit>Mhz|MIPS)\s+\:\s+(?<Value>[\d\.]+)" | 
                     Select-Object -First 1 -ExpandProperty Matches |
                     ForEach-Object {
                         $_.Groups["Value"].Value -as [int]
                     }
-            } elseif (Get-Variable -ErrorAction Ignore -ValueOnly IsMacOS) {
+            } elseif ($executionContext.SessionState.PSVariable.Get('IsMacOS').Value) {
                 (sysctl -n hw.cpufrequency) / 1e6 -as [int]
             } else {
                 $getCimInstance = $ExecutionContext.SessionState.InvokeCommand.GetCommand('Get-CimInstance','Cmdlet')


### PR DESCRIPTION
* Fixes the problem with the `Get-CimInstance` call missing a class name (since PSv3+ is now required, only `Get-CimInstance` needs to be looked for).
* Adds proper Linux detection
* Adds support for determining the CPU frequency on macOS